### PR TITLE
Check time between releases if latest version is not direct successor

### DIFF
--- a/piprot/models/version.py
+++ b/piprot/models/version.py
@@ -1,14 +1,23 @@
 import re
-from typing import List, Tuple
-
+from typing import List, Tuple, Optional
 
 PRERELEASE_REGEX = re.compile(r"(a|b|c|rc|alpha|beta|pre|preview|dev|svn|git)")
 
 
 class PiprotVersion:
-    def __init__(self, version: str, parts: List[int] = []) -> None:
+    def __init__(self, version: str) -> None:
         self.version = version
         self.parts = self.__version_to_parts()
+
+    def is_direct_successor(self, other: "PiprotVersion") -> bool:
+        if len(self.parts) != len(other.parts):
+            return False
+
+        return all(
+            self.parts[index] - other.parts[index] <= 1
+            for index, diff
+            in enumerate(self.parts)
+        )
 
     def __str__(self) -> str:  # pragma: no cover
         return str(self.version)

--- a/piprot/piprot.py
+++ b/piprot/piprot.py
@@ -30,7 +30,6 @@ def calculate_rotten_time(
 async def main(
     req_files: List[str],
     delay: int = 5,
-    calculate_rotten_between_releases: bool = False,
 ) -> None:
     requirements: List[Requirement] = []
     delay_timedelta = timedelta(days=delay)
@@ -66,7 +65,7 @@ async def main(
             continue
 
         if result.current_version != result.latest_version:
-            if calculate_rotten_between_releases:
+            if not result.latest_version.is_direct_successor(result.current_version):
                 if not all([result.latest_release_date, result.current_release_date]):
                     logger.warning(
                         f"Cannot calculate days out of date for {result.requirement.package}"
@@ -105,17 +104,6 @@ def piprot():
     """
     cli_parser = argparse.ArgumentParser(
         epilog="Here's hoping your requirements are nice and fresh!"
-    )
-
-    cli_parser.add_argument(
-        "--calculate-rotten-between-releases",
-        default=False,
-        type=bool,
-        help=(
-            "Should calculate days out of date between releases? "
-            "Defaults to False, meaning it will calculate delay "
-            "between latest release date and today."
-        ),
     )
 
     cli_parser.add_argument(


### PR DESCRIPTION
I got rid of `calculate_rotten_between_releases` param, as it was not really used (not passed to `main()` call 🤷‍♂️)

Instead, I've introduced quite _naïve_ way of checking whether we're dealing with direct version "successor" (e.g. 1.2.3 -> 1.2.4) - and then calculating days since latest release, or whether we're dealing with having possibly really rotten version (e.g. 1.2.3 -> 1.4.5) - and then calculating days between releases.

Hope that makes sense.